### PR TITLE
add swipedSetups data to db after user swiped, filter setups user already swiped

### DIFF
--- a/client/src/pages/Swipe.jsx
+++ b/client/src/pages/Swipe.jsx
@@ -12,7 +12,6 @@ import { ImageSwipe, ImageLike } from '../components'
 
 // TODO:
 // 1. check if user has liked/disliked currentSetup, if yes, skip to next setup
-// 2. connect with users collection, create liked array in users collection, add the setup id to liked arrayß
 
 const Swipe = () => {
   const [userId, setUserId] = useState(null);
@@ -98,7 +97,7 @@ const Swipe = () => {
     if (balanceSetups.length > 0) {      
 
       // update setup in db
-      fetch(`http://localhost:8080/api/setup/${currentSetup._id}`, {
+      fetch(`http://localhost:8080/api/setup/swipe/${currentSetup._id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -118,9 +117,38 @@ const Swipe = () => {
       .then((res) => res.json())
       .then((updatedSetup) => {
 
-        console.log(updatedSetup.swipes[updatedSetup.swipes.length-1])
+        console.log(`updatedSetup`, updatedSetup.swipes[updatedSetup.swipes.length-1])
 
         console.log(`Update Setup id ${updatedSetup._id} (${updatedSetup.title}) | by UserId ${updatedSetup.swipes[updatedSetup.swipes.length-1].userId} (${userEmail}) | LIKED? ${updatedSetup.swipes[updatedSetup.swipes.length-1].liked} | timestamp: ${updatedSetup.swipes[updatedSetup.swipes.length-1].timestamp}`);
+
+        // then also update user in db
+        fetch(`http://localhost:8080/api/user/${userId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            // push new swipe object to the swipedSetups array of this user
+            $push: {
+              "swipedSetups": {
+                "setupId": updatedSetup._id,
+                "liked": bool,
+                $currentDate: { 
+                  "lastModified": true,
+                  $type: "timestamp",
+                },
+              },
+            },
+          })
+        })
+        .then((res) => res.json())
+        .then((updatedUser) => {
+
+          console.log(`updatedUser`. updatedUser)
+          console.log(`updatedUser swipedSetups`, updatedUser.swipedSetups[updatedUser.swipedSetups.length-1])
+
+          console.log(`Update User id ${updatedUser._id} (${updatedUser.email}) | Swiped ${updatedUser.swipedSetups[updatedUser.swipedSetups.length-1].setupId} | LIKED? ${updatedUser.swipedSetups[updatedUser.swipedSetups.length-1].liked} | timestamp: ${updatedUser.swipedSetups[updatedUser.swipedSetups.length-1].timestamp}`);
+
+        })
+        .catch((err) => console.error({ error: err }));
 
       })
       .catch((err) => console.error({ error: err }));

--- a/client/src/pages/Swipe.jsx
+++ b/client/src/pages/Swipe.jsx
@@ -68,9 +68,51 @@ const Swipe = () => {
         // create temp array to store all setups
         let tempSetupsArray = parsedData;
 
+        // look through the tempSwipesArray
+        // if userId === one of the tempSwipesArray[i].userId 
+        // means user already liked/disliked this item
+        // so remove this item from the array
+        // then re-roll the array
+        // console.log(`tempSetupsArray`, tempSetupsArray);
+        console.log(`parsedData1111`, parsedData);
+
+        console.log(`userId`, userId)
+
+        // BUG / TODO:
+        // trying to filter away setups that user already swiped.
+        // doesn't work on page load. but after loading page, save the Swipe.jsx file in code editor, and should see frontend update with some setups removed from the balanceSetups.
+      
+        // loop through the parsedData (all setups)
+        for (let i=0; i<parsedData.length; i++) {
+          console.log(`in the loop, ${parsedData[i]}`)
+          // for each indiivdual setup, loop through the array for all swipes
+          for (let j=0; j<parsedData[i].swipes.length; j++) {
+            // check if the currently logged in userId === the userId in one of the swiped items
+            if (userId === parsedData[i].swipes[j].userId) {
+              console.log(`found that this setup ${parsedData[i].title} is already swiped!`)
+              // remove this item from the tempSetupsArray
+              console.log(`gonna remove this item`, tempSetupsArray[i].swipes[j]);
+              console.log(`gonna remove this setup`, tempSetupsArray[i]);
+              // tempSetupsArray[i].swipes.splice(j);
+              console.log(`removedSwipe:`, tempSetupsArray.splice(i, 1));
+
+              break;
+
+            }
+          }
+        }
+
+        console.log(`tempSetupsArray after for loop spaghetti`, tempSetupsArray);
+
         // randomly pick 1 setup (removes item from tempArray)
         let randomIndex = Math.floor(Math.random() * parsedData.length);
         let removedItem = tempSetupsArray.splice(randomIndex, 1); // returns array with 1 item
+
+        console.log(`parsedData selectedItem`, removedItem);
+
+
+        console.log(`parsedData selectedItem[0].swipes`, removedItem[0].swipes);
+
 
         // store randomly picked item as currentSetup to show on UI
         setCurrentSetup(removedItem[0]);
@@ -94,7 +136,9 @@ const Swipe = () => {
   // handle user click like button or swipe right on mobile
   const handleLiked = (bool) => {
 
-    if (balanceSetups.length > 0) {      
+    console.log(`Swiped Setup`, currentSetup);
+    
+    if (balanceSetups.length > 0) {
 
       // update setup in db
       fetch(`http://localhost:8080/api/setup/swipe/${currentSetup._id}`, {

--- a/client/src/pages/Swipe.jsx
+++ b/client/src/pages/Swipe.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
-import { ImageSwipe, ImageLike } from '../components'
-import { setup1 } from '../assets/setups'
 import { Container } from '@chakra-ui/react'
+
+import { ImageSwipe, ImageLike } from '../components'
 
 // randomly pick 1 of the items from all setups
 // if user swiped before, skip to next
@@ -15,8 +15,45 @@ import { Container } from '@chakra-ui/react'
 // 2. connect with users collection, create liked array in users collection, add the setup id to liked arrayß
 
 const Swipe = () => {
+  const [userId, setUserId] = useState(null);
+  const [userEmail, setUserEmail] = useState(null);
+
   const [currentSetup, setCurrentSetup] = useState({});
   const [balanceSetups, setBalanceSetups] = useState([]);
+
+  useEffect(() => {
+
+    // get user data
+    fetch(`http://localhost:8080/api/user/id`, {
+      method: `GET`,
+      credentials: `include`,
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        setUserId(data);
+        console.log(`userId`, userId);
+      })
+      .catch((e) => {
+        console.error(e);
+      });
+
+
+    fetch(`http://localhost:8080/api/user/${userId}`, {
+      method: `GET`,
+      credentials: `include`,
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        console.log(`data`, data);
+        setUserEmail(data.email);
+        // setRole(data.role);
+      })
+      .catch((e) => {
+        console.error(e);
+      });
+
+
+  }, [userId]);
 
   useEffect(() => {
 
@@ -68,7 +105,7 @@ const Swipe = () => {
           // push new swipe object to the swipes array of this setup
           $push: {
             "swipes": {
-              "userId": "Like recorded!",
+              "userId": userId,
               "liked": bool,
               $currentDate: { 
                 "lastModified": true,
@@ -80,7 +117,10 @@ const Swipe = () => {
       })
       .then((res) => res.json())
       .then((updatedSetup) => {
-        console.log(`Update Setup id ${updatedSetup._id} | LIKED? ${updatedSetup.swipes[updatedSetup.swipes.length-1].liked} | timestamp: ${updatedSetup.swipes[updatedSetup.swipes.length-1].timestamp}`);
+
+        console.log(updatedSetup.swipes[updatedSetup.swipes.length-1])
+
+        console.log(`Update Setup id ${updatedSetup._id} (${updatedSetup.title}) | by UserId ${updatedSetup.swipes[updatedSetup.swipes.length-1].userId} (${userEmail}) | LIKED? ${updatedSetup.swipes[updatedSetup.swipes.length-1].liked} | timestamp: ${updatedSetup.swipes[updatedSetup.swipes.length-1].timestamp}`);
 
       })
       .catch((err) => console.error({ error: err }));

--- a/server/mongodb/models/user.js
+++ b/server/mongodb/models/user.js
@@ -9,6 +9,13 @@ const UserSchema = new mongoose.Schema({
   tags: [{ type: String }],
   role: { type: String, enum: ['user', 'admin'], default: 'admin' },
   username: { type: String, trim: true },
+  swipedSetups: [
+    {
+      setupId: { type: String },
+      liked: { type: Boolean },
+      timestamp: { type: Date, default: Date.now },
+    },
+  ],
 });
 
 // UserSchema.post('save', function (doc, ext) {

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -135,6 +135,7 @@ router.get('/:id', async (req, res) => {
   }
 });
 
+//Update Route to update profile
 router.put('/:id', async (req, res) => {
   try {
     const updatedProfile = req.body;
@@ -149,6 +150,20 @@ router.put('/:id', async (req, res) => {
     res.status(200).json({ message: 'User profile updated successfully' });
   } catch (error) {
     res.status(400).json({ error: error.message });
+  }
+});
+
+//Update Route for swipe page 
+router.put('/swipe/:id', async (req, res) => {
+  try {
+    const updatedUser = await User.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      { new: true } // to return document after `update` was applied
+    );
+    res.status(200).send(updatedUser);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
   }
 });
 


### PR DESCRIPTION
attempts to solve two items described in [this comment](https://github.com/sov3333/ga-mern-project/issues/84#issuecomment-1486598457):

> * checking `user` to know which setup _id the user has already liked/disliked (and not show them),
> * connecting with `users` collection.

still buggy 
